### PR TITLE
Fix score updates stopping after golfer finishes round

### DIFF
--- a/app/services/importers/leaderboard_importer.rb
+++ b/app/services/importers/leaderboard_importer.rb
@@ -62,9 +62,10 @@ module Importers
         save_single_round(match_pick, round_number, strokes, player_status, player_position, "F")
       end
 
-      # Check if current round is in progress (not in rounds array yet)
+      # Check if current round needs saving via currentRoundScore
+      # (covers in-progress rounds AND the API lag window where roundComplete=true
+      # but the score hasn't yet moved into the rounds array)
       return unless current_round_num && current_round_num.between?(1, 4)
-      return if round_complete # Round is complete, should be in rounds array
 
       # Check if current round already exists in rounds array
       current_round_in_array = rounds.any? do |r|
@@ -103,6 +104,7 @@ module Importers
     # Assumes par 72 per round
     def convert_score_to_par_to_strokes(score_to_par)
       return nil unless score_to_par
+      return nil if score_to_par == "-" # API placeholder: player hasn't started yet
 
       par = @tournament.par || 72
 

--- a/spec/services/importers/leaderboard_importer_spec.rb
+++ b/spec/services/importers/leaderboard_importer_spec.rb
@@ -175,6 +175,111 @@ RSpec.describe Importers::LeaderboardImporter do
       expect(scores.find_by(round: 3).score).to eq(69)
       expect(scores.find_by(round: 4).score).to eq(68)
     end
+
+    it "saves score when roundComplete is true but round not yet in rounds array (API lag)" do
+      match_pick
+
+      lag_window_data = {
+        "leaderboardRows" => [
+          {
+            "playerId" => "46046",
+            "firstName" => "Scottie",
+            "lastName" => "Scheffler",
+            "status" => "active",
+            "roundComplete" => true,
+            "currentRound" => { "$numberInt" => "2" },
+            "currentRoundScore" => "-4",
+            "thru" => "F",
+            "rounds" => [
+              { "roundId" => { "$numberInt" => "1" }, "strokes" => { "$numberInt" => "70" } }
+              # Round 2 not yet in rounds array — API lag window
+            ]
+          }
+        ]
+      }
+
+      described_class.new(lag_window_data, tournament).process
+
+      scores = Score.where(match_pick: match_pick).order(:round)
+      expect(scores.count).to eq(2)
+      expect(scores.find_by(round: 1).score).to eq(70)
+      expect(scores.find_by(round: 2).score).to eq(tournament.par - 4)
+    end
+
+    it "continues updating second golfer scores after first golfer finishes their round" do
+      scheffler_pick = match_pick
+
+      mcilroy = create(:golfer, source_id: "28237", f_name: "Rory", l_name: "McIlroy")
+      mcilroy_pick = create(:match_pick, user: user, tournament: tournament, golfer: mcilroy, drafted: true)
+
+      data = {
+        "leaderboardRows" => [
+          {
+            "playerId" => "46046",
+            "status" => "complete",
+            "roundComplete" => true,
+            "currentRound" => { "$numberInt" => "2" },
+            "currentRoundScore" => "-3",
+            "thru" => "F",
+            "rounds" => [
+              { "roundId" => { "$numberInt" => "1" }, "strokes" => { "$numberInt" => "70" } },
+              { "roundId" => { "$numberInt" => "2" }, "strokes" => { "$numberInt" => "69" } }
+            ]
+          },
+          {
+            "playerId" => "28237",
+            "status" => "active",
+            "roundComplete" => false,
+            "currentRound" => { "$numberInt" => "2" },
+            "currentRoundScore" => "-2",
+            "thru" => "12",
+            "rounds" => [
+              { "roundId" => { "$numberInt" => "1" }, "strokes" => { "$numberInt" => "71" } }
+            ]
+          }
+        ]
+      }
+
+      described_class.new(data, tournament).process
+
+      mcilroy_r2 = Score.find_by(match_pick: mcilroy_pick, round: 2)
+      expect(mcilroy_r2).to be_present
+      expect(mcilroy_r2.score).to eq(tournament.par - 2)
+
+      # Second import: McIlroy's score improves
+      data["leaderboardRows"][1]["currentRoundScore"] = "-4"
+      data["leaderboardRows"][1]["thru"] = "16"
+
+      described_class.new(data, tournament).process
+
+      expect(mcilroy_r2.reload.score).to eq(tournament.par - 4)
+    end
+
+    it "does not save a bogus score when currentRoundScore is the placeholder dash" do
+      match_pick
+
+      no_score_data = {
+        "leaderboardRows" => [
+          {
+            "playerId" => "46046",
+            "status" => "active",
+            "roundComplete" => false,
+            "currentRound" => { "$numberInt" => "2" },
+            "currentRoundScore" => "-",
+            "thru" => "-",
+            "rounds" => [
+              { "roundId" => { "$numberInt" => "1" }, "strokes" => { "$numberInt" => "70" } }
+            ]
+          }
+        ]
+      }
+
+      described_class.new(no_score_data, tournament).process
+
+      scores = Score.where(match_pick: match_pick).order(:round)
+      expect(scores.count).to eq(1)
+      expect(scores.find_by(round: 2)).to be_nil
+    end
   end
 
   describe "#determine_current_round" do


### PR DESCRIPTION
## Summary
- Removes premature `return if round_complete` guard in `save_round_scores`
- Fixes API lag window where `roundComplete: true` is set before the score moves into the `rounds` array, causing subsequent golfers' in-progress scores to stop updating
- Adds `return nil if score_to_par == "-"` guard to prevent saving bogus placeholder scores

## Root cause
When a golfer finishes their round, the RapidAPI briefly sets `roundComplete: true` before moving the completed score into the `rounds` array. The early return fired during this lag window, skipping the `currentRoundScore` path and leaving the score unsaved for that import run.

## Test plan
- [ ] 3 new regression tests pass: API lag window, multi-golfer continuity, placeholder dash guard
- [ ] All 10 leaderboard importer tests pass
- [ ] Full suite passes (518 examples, 1 pre-existing failure unrelated to this change)
- [ ] Rubocop clean