### PR TITLE
Fix stale DB token blocking login

### DIFF
--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -6,7 +6,7 @@ module Api
       user = User.find_by(email: params[:email])
 
       if user&.valid_password?(params[:password])
-        user.ensure_authentication_token!
+        user.rotate_authentication_token!
         render_success({
           user: user_data(user),
           token: user.plain_token

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -27,7 +27,7 @@ class Users::SessionsController < ApplicationController
       user.sign_in_count += 1
       user.save!
 
-      user.ensure_authentication_token!
+      user.rotate_authentication_token!
       render json: {
         user: {
           id: user.id,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,9 +20,17 @@ class User < ApplicationRecord
   # after ensure_authentication_token! is called; nil on any subsequent reload.
   attr_reader :plain_token
 
+  # Clears any existing token and generates a fresh one. Always call this on
+  # login so a stale DB token never silences plain_token.
+  def rotate_authentication_token!
+    update_column(:authentication_token, nil) if authentication_token.present?
+    ensure_authentication_token!
+  end
+
   # Generates a plain token, stores its SHA-256 hash in the DB, and exposes
   # the plain token via #plain_token for the duration of this object's lifetime.
-  # No-op if a token hash is already stored.
+  # No-op if a token hash is already stored. Use rotate_authentication_token!
+  # on login to always get a fresh token.
   def ensure_authentication_token!
     return if authentication_token.present?
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -53,6 +53,40 @@ RSpec.describe User, type: :model do
       end
     end
 
+    describe "#rotate_authentication_token!" do
+      it "generates a token when none exists" do
+        user = create(:user)
+        user.rotate_authentication_token!
+        expect(user.plain_token).to be_present
+        expect(user.plain_token.length).to eq(20)
+      end
+
+      it "replaces an existing token with a new one" do
+        user = create(:user)
+        user.ensure_authentication_token!
+        original_hash = user.authentication_token
+
+        user.rotate_authentication_token!
+
+        expect(user.plain_token).to be_present
+        user.reload
+        expect(user.authentication_token).not_to eq(original_hash)
+        expect(user.authentication_token).to eq(Digest::SHA256.hexdigest(user.plain_token))
+      end
+
+      it "always sets plain_token even on a freshly loaded instance" do
+        user = create(:user)
+        user.ensure_authentication_token!
+
+        # Fresh DB load: @plain_token ivar is not set
+        fresh = User.find(user.id)
+        expect(fresh.plain_token).to be_nil
+
+        fresh.rotate_authentication_token!
+        expect(fresh.plain_token).to be_present
+      end
+    end
+
     describe ".find_by_token" do
       it "finds a user by their plain token" do
         user = create(:user)

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -59,6 +59,24 @@ RSpec.describe 'Users::Sessions', type: :request do
         expect(user.current_sign_in_ip).to be_present
       end
 
+      it 'issues a fresh token even when an existing token is already stored' do
+        # Simulate a stale DB token (e.g. logout failed at network level)
+        user.ensure_authentication_token!
+        stale_hash = user.authentication_token
+        expect(stale_hash).to be_present
+
+        post '/users/sign_in', params: login_params, as: :json
+
+        expect(response).to have_http_status(:ok)
+        json_response = JSON.parse(response.body)
+        expect(json_response['token']).to be_present
+
+        user.reload
+        # Hash must have rotated
+        expect(user.authentication_token).not_to eq(stale_hash)
+        expect(user.authentication_token).to eq(Digest::SHA256.hexdigest(json_response['token']))
+      end
+
       it 'updates last sign in on subsequent logins' do
         # First login
         post '/users/sign_in', params: login_params, as: :json


### PR DESCRIPTION
## Summary
- Adds `rotate_authentication_token!` to `User` model — always clears the existing DB token then generates a fresh one
- Sessions controller now calls `rotate_authentication_token!` on every successful login instead of `ensure_authentication_token!`
- Same fix applied to `Api::AuthController`

## Root Cause
`ensure_authentication_token!` is a no-op when `authentication_token` is already present in the DB. If a logout request ever fails at the network level, the frontend `finally` clears localStorage but the DB token is never cleared. The next login returns `token: null` (since `plain_token` is never set), the frontend stores `"null"`, and every subsequent API request returns 401. Password reset doesn't fix it — it doesn't touch `authentication_token`, so the stale DB token persists through the reset.

## Test plan
- [ ] `rspec spec/models/user_spec.rb` — 3 new tests for `rotate_authentication_token!`
- [ ] `rspec spec/requests/users/sessions_spec.rb` — 1 new test: "issues a fresh token even when an existing token is already stored"
- [ ] Full suite passes (1 pre-existing unrelated failure in draft_controller_spec)