### PR TITLE
Add tournament conclusion system

### DIFF
--- a/app/jobs/leaderboard_import_job.rb
+++ b/app/jobs/leaderboard_import_job.rb
@@ -29,6 +29,9 @@ class LeaderboardImportJob < ApplicationJob
 
     # Save full leaderboard snapshot for display
     save_leaderboard_snapshot(tournament, api_data)
+
+    # Trigger match results if this is the final scheduled update for the tournament
+    trigger_match_results_if_final(tournament)
   end
 
   def setup
@@ -36,6 +39,28 @@ class LeaderboardImportJob < ApplicationJob
   end
 
   private
+
+  def trigger_match_results_if_final(tournament)
+    return if tournament.concluded?
+
+    today = Date.current
+    tournament_end = tournament.end_date.to_date
+
+    tz = tournament_timezone(tournament)
+    local_time = Time.current.in_time_zone(tz)
+    is_final_update = local_time.hour == 20 && local_time.min == 0
+    is_past_end = today > tournament_end
+
+    return unless is_final_update || is_past_end
+
+    # On end_date the 8PM update fires — on post-end days any run triggers
+    return unless today >= tournament_end
+
+    Rails.logger.info "Triggering MatchResultsJob for #{tournament.name} (post-tournament update)"
+    MatchResultsJob.perform_later(tournament.id)
+  rescue StandardError => e
+    Rails.logger.error "Failed to trigger MatchResultsJob: #{e.message}"
+  end
 
   def save_leaderboard_snapshot(tournament, api_data)
     return unless api_data["leaderboardRows"].present?

--- a/app/jobs/match_results_job.rb
+++ b/app/jobs/match_results_job.rb
@@ -1,10 +1,9 @@
 class MatchResultsJob < ApplicationJob
   queue_as :default
 
-  def perform
+  def perform(tournament_id = nil)
     setup
-    # Get previous tournament (tournament that just completed)
-    tournament = @tournament_service.previous_tournament
+    tournament = find_tournament(tournament_id)
 
     return nil if tournament.blank?
 
@@ -13,15 +12,23 @@ class MatchResultsJob < ApplicationJob
       return nil
     end
 
-    # Calculate and store match results
     BusinessLogic::MatchResultsCalculationService.new(tournament).calculate
-    Rails.logger.info "Match results calculated successfully for #{tournament.name}"
+    tournament.update_column(:concluded, true)
+    Rails.logger.info "Match results calculated and tournament concluded: #{tournament.name}"
   rescue StandardError => e
     Rails.logger.error "MatchResultsJob failed for tournament #{tournament&.name}: #{e.message}"
     raise
   end
 
+  private
+
   def setup
     @tournament_service = BusinessLogic::TournamentService.new
+  end
+
+  def find_tournament(tournament_id)
+    return Tournament.find(tournament_id) if tournament_id.present?
+
+    @tournament_service.previous_tournament
   end
 end

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -33,4 +33,8 @@ class Tournament < ApplicationRecord
   def self.any_in_progress?(current_date = Date.current)
     where("DATE(start_date) <= ? AND DATE(end_date) >= ?", current_date, current_date).exists?
   end
+
+  def concluded?
+    concluded
+  end
 end

--- a/app/services/api/tournament_results_service.rb
+++ b/app/services/api/tournament_results_service.rb
@@ -24,7 +24,7 @@ module Api
     private
 
     def completed?(tournament)
-      tournament.end_date < Date.current
+      tournament.concluded? || tournament.end_date.to_date < Date.current
     end
 
     def tournament_data(tournament)

--- a/app/services/business_logic/tournament_service.rb
+++ b/app/services/business_logic/tournament_service.rb
@@ -48,10 +48,9 @@ module BusinessLogic
       # Guard: if a current tournament exists, we are not in the transition period
       return nil if current_tournament.present?
 
-      # Return the most recently ended tournament for this year
-      # (regardless of whether match results have been calculated yet)
+      # Return the most recently concluded tournament for this year
       Tournament.where(year: @date.year)
-                .where("end_date < ?", @date)
+                .where(concluded: true)
                 .order(end_date: :desc)
                 .first
     end
@@ -87,7 +86,8 @@ module BusinessLogic
     def fetch_current_tournaments
       Tournament.where(
         week_number: current_week,
-        year: @date.year
+        year: @date.year,
+        concluded: false
       )
     end
 

--- a/db/migrate/20260504021056_add_concluded_to_tournaments.rb
+++ b/db/migrate/20260504021056_add_concluded_to_tournaments.rb
@@ -1,0 +1,9 @@
+class AddConcludedToTournaments < ActiveRecord::Migration[8.0]
+  def change
+    add_column :tournaments, :concluded, :boolean, default: false, null: false
+    # Backfill: past tournaments (end_date before today) are considered concluded
+    reversible do |dir|
+      dir.up { Tournament.where("end_date < ?", Date.current).update_all(concluded: true) }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_30_113659) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_04_021056) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -97,6 +97,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_30_113659) do
     t.integer "par", default: 72, null: false
     t.integer "purse"
     t.string "unique_id"
+    t.boolean "concluded", default: false, null: false
     t.index ["source_id"], name: "index_tournaments_on_source_id"
     t.index ["tournament_id", "year"], name: "index_tournaments_on_tournament_id_and_year"
   end

--- a/spec/jobs/leaderboard_import_job_spec.rb
+++ b/spec/jobs/leaderboard_import_job_spec.rb
@@ -208,6 +208,89 @@ RSpec.describe LeaderboardImportJob, type: :job do
     end
   end
 
+  describe "match results trigger" do
+    include ActiveSupport::Testing::TimeHelpers
+
+    before { ActiveJob::Base.queue_adapter = :test }
+    after  { ActiveJob::Base.queue_adapter = :async }
+
+    let(:end_date_tournament) do
+      create(:tournament,
+             tournament_id: "500",
+             name: "Trigger Tournament",
+             end_date: Date.new(2026, 6, 7),
+             concluded: false)
+    end
+
+    before do
+      tournament_service_double = instance_double(BusinessLogic::TournamentService)
+      allow(BusinessLogic::TournamentService).to receive(:new).and_return(tournament_service_double)
+      allow(tournament_service_double).to receive(:current_tournament).and_return(end_date_tournament)
+
+      allow(leaderboard_client).to receive(:fetch).with(end_date_tournament.tournament_id).and_return(api_data)
+      allow(Importers::LeaderboardImporter).to receive(:new).with(api_data, end_date_tournament).and_return(leaderboard_importer)
+      allow_any_instance_of(described_class).to receive(:scheduled_time?).and_return(true)
+    end
+
+    context "at 8PM on the tournament end_date" do
+      it "enqueues MatchResultsJob" do
+        travel_to Time.find_zone("America/New_York").local(2026, 6, 7, 20, 0, 0) do
+          expect { described_class.perform_now }.to have_enqueued_job(MatchResultsJob).with(end_date_tournament.id)
+        end
+      end
+    end
+
+    context "at 10AM on the tournament end_date (not final update)" do
+      it "does not enqueue MatchResultsJob" do
+        travel_to Time.find_zone("America/New_York").local(2026, 6, 7, 10, 0, 0) do
+          expect { described_class.perform_now }.not_to have_enqueued_job(MatchResultsJob)
+        end
+      end
+    end
+
+    context "on a day after the tournament end_date (any time)" do
+      it "enqueues MatchResultsJob regardless of target time" do
+        travel_to Time.find_zone("America/New_York").local(2026, 6, 8, 10, 0, 0) do
+          expect { described_class.perform_now }.to have_enqueued_job(MatchResultsJob).with(end_date_tournament.id)
+        end
+      end
+    end
+
+    context "when tournament is already concluded" do
+      before { end_date_tournament.update_column(:concluded, true) }
+
+      it "does not enqueue MatchResultsJob again" do
+        travel_to Time.find_zone("America/New_York").local(2026, 6, 7, 20, 0, 0) do
+          expect { described_class.perform_now }.not_to have_enqueued_job(MatchResultsJob)
+        end
+      end
+    end
+
+    context "before the tournament end_date" do
+      let(:future_end_tournament) do
+        create(:tournament,
+               tournament_id: "501",
+               name: "Mid Tournament",
+               end_date: Date.new(2026, 6, 10),
+               concluded: false)
+      end
+
+      before do
+        tournament_service_double = instance_double(BusinessLogic::TournamentService)
+        allow(BusinessLogic::TournamentService).to receive(:new).and_return(tournament_service_double)
+        allow(tournament_service_double).to receive(:current_tournament).and_return(future_end_tournament)
+        allow(leaderboard_client).to receive(:fetch).with(future_end_tournament.tournament_id).and_return(api_data)
+        allow(Importers::LeaderboardImporter).to receive(:new).with(api_data, future_end_tournament).and_return(leaderboard_importer)
+      end
+
+      it "does not enqueue MatchResultsJob mid-tournament" do
+        travel_to Time.find_zone("America/New_York").local(2026, 6, 8, 20, 0, 0) do
+          expect { described_class.perform_now }.not_to have_enqueued_job(MatchResultsJob)
+        end
+      end
+    end
+  end
+
   describe "timezone-aware scheduling" do
     include ActiveSupport::Testing::TimeHelpers
 

--- a/spec/jobs/match_results_job_spec.rb
+++ b/spec/jobs/match_results_job_spec.rb
@@ -2,7 +2,10 @@ require 'rails_helper'
 
 RSpec.describe MatchResultsJob, type: :job do
   let(:tournament_service) { instance_double(BusinessLogic::TournamentService) }
-  let(:tournament) { instance_double(Tournament, name: 'Test Championship', match_results: match_results_relation) }
+  let(:tournament) do
+    instance_double(Tournament, id: 99, name: 'Test Championship',
+                                match_results: match_results_relation)
+  end
   let(:match_results_relation) { instance_double(ActiveRecord::Associations::CollectionProxy) }
   let(:calculation_service) { instance_double(BusinessLogic::MatchResultsCalculationService) }
 
@@ -11,18 +14,48 @@ RSpec.describe MatchResultsJob, type: :job do
     allow(BusinessLogic::MatchResultsCalculationService).to receive(:new).with(tournament).and_return(calculation_service)
     allow(match_results_relation).to receive(:exists?).and_return(false)
     allow(calculation_service).to receive(:calculate)
+    allow(tournament).to receive(:update_column).with(:concluded, true)
   end
 
   describe '#perform' do
-    context 'when a previous tournament exists with no results' do
+    context 'when called without tournament_id (Monday cron path)' do
       before do
         allow(tournament_service).to receive(:previous_tournament).and_return(tournament)
         allow(Rails.logger).to receive(:info)
       end
 
+      it 'uses previous_tournament from TournamentService' do
+        expect(tournament_service).to receive(:previous_tournament)
+        described_class.perform_now
+      end
+
       it 'calls calculate on the calculation service' do
         expect(calculation_service).to receive(:calculate)
         described_class.perform_now
+      end
+
+      it 'marks the tournament as concluded after calculating' do
+        expect(tournament).to receive(:update_column).with(:concluded, true)
+        described_class.perform_now
+      end
+    end
+
+    context 'when called with a tournament_id (leaderboard trigger path)' do
+      before do
+        allow(Tournament).to receive(:find).with(99).and_return(tournament)
+        allow(Rails.logger).to receive(:info)
+      end
+
+      it 'looks up tournament by id instead of using TournamentService' do
+        expect(Tournament).to receive(:find).with(99)
+        expect(tournament_service).not_to receive(:previous_tournament)
+        described_class.perform_now(99)
+      end
+
+      it 'calculates and concludes the tournament' do
+        expect(calculation_service).to receive(:calculate)
+        expect(tournament).to receive(:update_column).with(:concluded, true)
+        described_class.perform_now(99)
       end
     end
 
@@ -35,6 +68,11 @@ RSpec.describe MatchResultsJob, type: :job do
 
       it 'does not call calculate' do
         expect(calculation_service).not_to receive(:calculate)
+        described_class.perform_now
+      end
+
+      it 'does not mark tournament as concluded' do
+        expect(tournament).not_to receive(:update_column)
         described_class.perform_now
       end
     end
@@ -63,12 +101,13 @@ RSpec.describe MatchResultsJob, type: :job do
       end
 
       it 'logs the error before re-raising' do
-        begin
-          described_class.perform_now
-        rescue StandardError
-          nil
-        end
+        described_class.perform_now rescue nil
         expect(Rails.logger).to have_received(:error).with(/MatchResultsJob failed for tournament Test Championship: DB connection failed/)
+      end
+
+      it 'does not mark tournament as concluded on failure' do
+        described_class.perform_now rescue nil
+        expect(tournament).not_to have_received(:update_column).with(:concluded, true)
       end
     end
   end

--- a/spec/services/business_logic/tournament_service_spec.rb
+++ b/spec/services/business_logic/tournament_service_spec.rb
@@ -36,6 +36,20 @@ RSpec.describe BusinessLogic::TournamentService do
       end
     end
 
+    context 'when the current-week tournament is concluded' do
+      let!(:concluded_tournament) do
+        create(:tournament,
+               week_number: test_date.strftime("%V").to_i,
+               year: test_date.year,
+               concluded: true,
+               name: 'Concluded Tournament')
+      end
+
+      it 'returns nil (concluded tournaments are not "current")' do
+        expect(service.current_tournament).to be_nil
+      end
+    end
+
     context 'with multiple tournaments for the current week' do
       let!(:regular_tournament) do
         create(:tournament,
@@ -194,13 +208,14 @@ RSpec.describe BusinessLogic::TournamentService do
       end
     end
 
-    context 'with a recently ended tournament that has match_results' do
+    context 'with a recently concluded tournament that has match_results' do
       let!(:completed_tournament) do
         create(:tournament,
                week_number: test_date.strftime("%V").to_i - 1,
                year: test_date.year,
                start_date: test_date - 6.days,
                end_date: test_date - 2.days,
+               concluded: true,
                name: 'Last Week Tournament')
       end
 
@@ -208,33 +223,51 @@ RSpec.describe BusinessLogic::TournamentService do
         create(:match_result, tournament: completed_tournament, user: create(:user), place: 1)
       end
 
-      it 'returns the most recently ended tournament' do
+      it 'returns the most recently concluded tournament' do
         expect(service.recently_completed_tournament).to eq(completed_tournament)
       end
     end
 
-    context 'with an ended tournament that has no match_results yet' do
+    context 'with an ended tournament that has no match_results yet but is concluded' do
       let!(:completed_without_results) do
         create(:tournament,
                week_number: test_date.strftime("%V").to_i - 1,
                year: test_date.year,
                start_date: test_date - 6.days,
                end_date: test_date - 2.days,
+               concluded: true,
                name: 'Tournament Without Results')
       end
 
-      it 'returns the tournament even without match_results (transition shows immediately)' do
+      it 'returns the tournament (transition shows immediately after conclusion)' do
         expect(service.recently_completed_tournament).to eq(completed_without_results)
       end
     end
 
-    context 'when the only ended tournament is from a prior year' do
+    context 'with an ended tournament that is not yet concluded' do
+      let!(:not_concluded) do
+        create(:tournament,
+               week_number: test_date.strftime("%V").to_i - 1,
+               year: test_date.year,
+               start_date: test_date - 6.days,
+               end_date: test_date - 2.days,
+               concluded: false,
+               name: 'Not Yet Concluded')
+      end
+
+      it 'returns nil (transition state only starts after concluded flag is set)' do
+        expect(service.recently_completed_tournament).to be_nil
+      end
+    end
+
+    context 'when the only concluded tournament is from a prior year' do
       let!(:prior_year_tournament) do
         create(:tournament,
                week_number: 50,
                year: test_date.year - 1,
                start_date: Date.new(test_date.year - 1, 12, 10),
                end_date: Date.new(test_date.year - 1, 12, 13),
+               concluded: true,
                name: 'Last Year Tournament')
       end
 


### PR DESCRIPTION
## Summary
- Adds `concluded` boolean to `tournaments` (backfills past tournaments)
- `MatchResultsJob` now accepts a `tournament_id`, sets `concluded: true` after success
- `LeaderboardImportJob` auto-triggers `MatchResultsJob` at the 8PM score update on/after end_date (Monday cron remains as safety net)
- `TournamentService` excludes concluded tournaments from `current_tournament` and uses `concluded: true` for `recently_completed_tournament`
- `TournamentResultsService` accepts concluded tournaments on the same day they finish

## Test plan
- [ ] Run `rails db:migrate` on production (adds `concluded` column, backfills past tournaments)
- [ ] Verify 548 backend tests pass (2 pre-existing failures unrelated to this change)
- [ ] Confirm `MatchResultsJob.perform_now(tournament_id)` correctly calculates and sets `concluded: true`
- [ ] Confirm `LeaderboardImportJob` enqueues `MatchResultsJob` on 8PM end_date run

🤖 Generated with [Claude Code](https://claude.com/claude-code)