### PR TITLE
Add 2-week token TTL

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,36 +20,42 @@ class User < ApplicationRecord
   # after ensure_authentication_token! is called; nil on any subsequent reload.
   attr_reader :plain_token
 
+  TOKEN_TTL = 2.weeks
+
   # Clears any existing token and generates a fresh one. Always call this on
   # login so a stale DB token never silences plain_token.
   def rotate_authentication_token!
-    update_column(:authentication_token, nil) if authentication_token.present?
+    update_columns(authentication_token: nil, token_expires_at: nil) if authentication_token.present?
     ensure_authentication_token!
   end
 
-  # Generates a plain token, stores its SHA-256 hash in the DB, and exposes
-  # the plain token via #plain_token for the duration of this object's lifetime.
-  # No-op if a token hash is already stored. Use rotate_authentication_token!
-  # on login to always get a fresh token.
+  # Generates a plain token, stores its SHA-256 hash in the DB, sets a 2-week
+  # expiry, and exposes the plain token via #plain_token for the duration of
+  # this object's lifetime. No-op if a valid unexpired token is already stored.
   def ensure_authentication_token!
-    return if authentication_token.present?
+    return if authentication_token.present? && token_expires_at&.future?
 
     loop do
       plain = Devise.friendly_token
       hashed = Digest::SHA256.hexdigest(plain)
       next if User.where.not(id: id).exists?(authentication_token: hashed)
 
-      update_column(:authentication_token, hashed)
+      update_columns(authentication_token: hashed, token_expires_at: TOKEN_TTL.from_now)
       @plain_token = plain
       break
     end
   end
 
-  # Looks up a user by hashing the incoming bearer token and comparing to stored hash.
+  # Looks up a user by hashing the incoming bearer token, checking expiry.
+  # Returns nil for blank, unknown, or expired tokens.
   def self.find_by_token(token)
     return nil if token.blank?
 
-    find_by(authentication_token: Digest::SHA256.hexdigest(token))
+    user = find_by(authentication_token: Digest::SHA256.hexdigest(token))
+    return nil if user.nil?
+    return nil if user.token_expires_at.nil? || user.token_expires_at.past?
+
+    user
   end
 
   private

--- a/db/migrate/20260509124229_add_token_expires_at_to_users.rb
+++ b/db/migrate/20260509124229_add_token_expires_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddTokenExpiresAtToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :token_expires_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_04_021056) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_09_124229) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -121,6 +121,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_04_021056) do
     t.datetime "last_sign_in_at"
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
+    t.datetime "token_expires_at"
     t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -33,13 +33,30 @@ RSpec.describe User, type: :model do
         expect(user.authentication_token).to eq(Digest::SHA256.hexdigest(user.plain_token))
       end
 
-      it "is a no-op when a token hash is already stored" do
+      it "sets token_expires_at to 2 weeks from now" do
+        user = create(:user)
+        user.ensure_authentication_token!
+        expect(user.token_expires_at).to be_within(5.seconds).of(2.weeks.from_now)
+      end
+
+      it "is a no-op when a valid unexpired token is already stored" do
         user = create(:user)
         user.ensure_authentication_token!
         original_hash = user.authentication_token
 
         user.ensure_authentication_token!
         expect(user.authentication_token).to eq(original_hash)
+      end
+
+      it "regenerates when token is expired" do
+        user = create(:user)
+        user.ensure_authentication_token!
+        original_hash = user.authentication_token
+        user.update_column(:token_expires_at, 1.minute.ago)
+
+        user.ensure_authentication_token!
+        expect(user.authentication_token).not_to eq(original_hash)
+        expect(user.token_expires_at).to be_within(5.seconds).of(2.weeks.from_now)
       end
 
       it "generates unique hashes for different users" do
@@ -74,6 +91,15 @@ RSpec.describe User, type: :model do
         expect(user.authentication_token).to eq(Digest::SHA256.hexdigest(user.plain_token))
       end
 
+      it "resets token_expires_at to 2 weeks from now" do
+        user = create(:user)
+        user.ensure_authentication_token!
+        user.update_column(:token_expires_at, 1.day.from_now)
+
+        user.rotate_authentication_token!
+        expect(user.token_expires_at).to be_within(5.seconds).of(2.weeks.from_now)
+      end
+
       it "always sets plain_token even on a freshly loaded instance" do
         user = create(:user)
         user.ensure_authentication_token!
@@ -103,6 +129,30 @@ RSpec.describe User, type: :model do
       it "returns nil for a blank token" do
         expect(User.find_by_token(nil)).to be_nil
         expect(User.find_by_token("")).to be_nil
+      end
+
+      it "returns nil for an expired token" do
+        user = create(:user)
+        user.ensure_authentication_token!
+        user.update_column(:token_expires_at, 1.minute.ago)
+
+        expect(User.find_by_token(user.plain_token)).to be_nil
+      end
+
+      it "returns nil when token_expires_at is nil" do
+        user = create(:user)
+        user.ensure_authentication_token!
+        user.update_columns(token_expires_at: nil)
+
+        expect(User.find_by_token(user.plain_token)).to be_nil
+      end
+
+      it "returns the user when token is not yet expired" do
+        user = create(:user)
+        user.ensure_authentication_token!
+        user.update_column(:token_expires_at, 13.days.from_now)
+
+        expect(User.find_by_token(user.plain_token)).to eq(user)
       end
     end
 


### PR DESCRIPTION
## Summary
- Adds `token_expires_at` datetime column to users
- `ensure_authentication_token!` sets expiry 2 weeks from now; regenerates if expired
- `find_by_token` returns nil for expired or missing expiry tokens
- Existing tokens (nil expiry) treated as expired — users re-authenticate once after deploy

## Test plan
- [ ] Run `rails db:migrate` on production
- [ ] 554 tests pass (1 pre-existing failure)
- [ ] Log in, confirm session persists across browser restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)